### PR TITLE
Added IgnoreCase property 

### DIFF
--- a/HighlightSample/MainWindow.xaml
+++ b/HighlightSample/MainWindow.xaml
@@ -19,6 +19,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -27,12 +28,15 @@
         </Grid.ColumnDefinitions>
         <TextBlock Text="Input" />
         <TextBlock Grid.Row="1" Text="Search"/>
-        <TextBlock Grid.Row="2" Text="Output"/>
+        <TextBlock Grid.Row="2" Text="Ignore Case"/>
+        <TextBlock Grid.Row="3" Text="Output"/>
         <TextBox Grid.Column="1" x:Name="full" Text="{Binding Path=FullText, UpdateSourceTrigger=PropertyChanged}"/>
         <TextBox Grid.Row="1" Grid.Column="1" x:Name="filter" Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"/>
-        <TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding Path=Text, ElementName=full}"
+        <CheckBox Grid.Row="2" Grid.Column="1" x:Name="ignoreCase"></CheckBox>
+        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Path=Text, ElementName=full}"
                    controls:HighlightableTextBlock.HightlightText="{Binding Filter}" controls:HighlightableTextBlock.Italic="True"
                    controls:HighlightableTextBlock.HighlightBrush="Yellow" controls:HighlightableTextBlock.HighlightTextBrush="Red"
-                   controls:HighlightableTextBlock.Bold="True"/>
+                   controls:HighlightableTextBlock.Bold="True"
+                   controls:HighlightableTextBlock.IgnoreCase="{Binding ElementName=ignoreCase, Path=IsChecked}"/>
     </Grid>
 </Window>

--- a/HighlightableTextblock/HighlightableTextBlock.cs
+++ b/HighlightableTextblock/HighlightableTextBlock.cs
@@ -27,6 +27,24 @@ namespace HighlightableTextBlock
             DependencyProperty.RegisterAttached("Bold", typeof(bool), typeof(HighlightableTextBlock), new PropertyMetadata(false, Refresh));
 
         #endregion
+        
+        #region IgnoreCase
+
+        public static bool GetIgnoreCase(DependencyObject obj)
+        {
+            return (bool) obj.GetValue(IgnoreCaseProperty);
+        }
+
+        public static void SetIgnoreCase(DependencyObject obj, bool value)
+        {
+            obj.SetValue(IgnoreCaseProperty, value);
+        }
+
+        public static readonly DependencyProperty IgnoreCaseProperty = DependencyProperty
+            .RegisterAttached("IgnoreCase", typeof(bool), typeof(HighlightableTextBlock),
+                new PropertyMetadata(false, Refresh));
+        
+        #endregion
 
         #region Italic
 
@@ -210,7 +228,9 @@ namespace HighlightableTextBlock
 
                 if (!String.IsNullOrEmpty(toHighlight))
                 {
-                    var matches = Regex.Split(text, String.Format("({0})", Regex.Escape(toHighlight)), RegexOptions.IgnoreCase);
+                    var regexOptions = GetIgnoreCase(textblock) ? RegexOptions.IgnoreCase : RegexOptions.None;
+                    
+                    var matches = Regex.Split(text, String.Format("({0})", Regex.Escape(toHighlight)), regexOptions);
 
                     textblock.Inlines.Clear();
 


### PR DESCRIPTION
This is intended to allow users to ignore case on the fly by binding to other properties., such as a checkbox. This has been added to the sample app as well. 